### PR TITLE
Run apt update as part of package installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,15 +5,9 @@
     msg: "The operating system of the target machine ({{ inventory_hostname }}) is not currently supported"
   when: not (ansible_os_family == 'Debian' or ansible_distribution == 'Ubuntu')
 
-- name: Debian | run apt update
-  sudo: yes
-  apt: update_cache=yes
-  tags:
-    - automysqlbackup
-
 - name: Debian | install automysqlbackup
   sudo: yes
-  apt: pkg=automysqlbackup state=latest
+  apt: pkg=automysqlbackup state=latest update_cache=yes
   tags:
     - automysqlbackup
 


### PR DESCRIPTION
This speeds up Ansible runs by not running an update multiple times when it's not needed.
